### PR TITLE
Fix for python 3.10

### DIFF
--- a/src/clamd/asynchronous.py
+++ b/src/clamd/asynchronous.py
@@ -22,14 +22,14 @@ class ClamdAsyncNetworkSocket(object):
         self.port = port
         self.timeout = timeout
 
-    async def _init_socket(self, loop=None):
+    async def _init_socket(self):
         """
         internal use only
         """
         connection = asyncio.open_connection(self.host, self.port)
 
         try:
-            return await asyncio.wait_for(connection, self.timeout, loop=loop)
+            return await asyncio.wait_for(connection, self.timeout)
         except asyncio.TimeoutError as e:
             raise ConnectionError("Timeout connecting to {host}:{port}")
         except ConnectionRefusedError as e:


### PR DESCRIPTION
Quoting the python 3.10 changelog:
> The loop parameter has been removed from most of asyncio‘s high-level API following deprecation in Python 3.8.

https://docs.python.org/3/whatsnew/3.10.html